### PR TITLE
Fixed the interference between bot APIs during tournaments

### DIFF
--- a/lib/classes/api.js
+++ b/lib/classes/api.js
@@ -1,6 +1,4 @@
-GridGame.apis = [];
 GridGame.classes.api = function (player, config) {
-  GridGame.apis.push(this);
   this.player = player;
 
   this.get_named_bot = function (name) {
@@ -25,11 +23,15 @@ GridGame.classes.api = function (player, config) {
     }
   };
   this.implement_code = function (code) {
-    var api = this;
     this.func = function () {
+      var api = this;
       eval(code);
-    };
+    }.bind(Object.assign({}, this));
     //this.code_field.val(code);
+  };
+  this.reset = function () {
+    this.func = this.func.bind(Object.assign({}, this));
+    this.next_move = 0;
   };
 
   // This point onwards is the public API

--- a/lib/classes/player.js
+++ b/lib/classes/player.js
@@ -10,6 +10,7 @@ GridGame.classes.player = function (config) {
   this.key_map = GridGame.data.key_maps[this.name];
 
   this.direction = config.direction;
+  this.movelog = "";
   this.dead = false;
 
   this.init = function () {

--- a/lib/grid_game.js
+++ b/lib/grid_game.js
@@ -75,6 +75,7 @@ GridGame = {
           // TODO
           player.build_first_city();
           player.api.reset();
+          player.movelog = "";
           player.still_alive = true;
           player.dead = false;
         }
@@ -121,6 +122,9 @@ GridGame = {
       if (GridGame.turn_number >= api.next_move) {
         api.func()
       }
+    });
+    $.each(GridGame.players, function (i, player) {
+      player.movelog += player.direction[0];
     });
     GridGame.set_players_dead();
 

--- a/lib/grid_game.js
+++ b/lib/grid_game.js
@@ -56,12 +56,14 @@ GridGame = {
   init_players: function () {
     if (this.players === undefined) {
       this.players = [];
+      this.apis = [];
       $.each(
         GridGame.data.players,
         function (index, player_config) {
           if (this.players === undefined) {
             player = new GridGame.classes.player(player_config);
             GridGame.players.push(player);
+            GridGame.apis.push(player.api);
           }
           player.init();
         }
@@ -72,7 +74,7 @@ GridGame = {
         function (i, player) {
           // TODO
           player.build_first_city();
-          player.api = new GridGame.classes.api(player, player.config);
+          player.api.reset();
           player.still_alive = true;
           player.dead = false;
         }
@@ -195,6 +197,9 @@ GridGame = {
 
   reset: function () {
     this.init(GridGame.init_data);
+    $.each(GridGame.apis, function (i, api) {
+      api.reset();
+    });
   },
   gist_cache: {}
 };

--- a/lib/runner/match_runner.js
+++ b/lib/runner/match_runner.js
@@ -46,6 +46,11 @@ MatchRunner = function (green_gist, red_gist) {
       result,
       GridGame.turn_number
     );
+    fs.appendFile(
+      'data/movelog.txt',
+      green_gist+': '+GridGame.players[0].movelog+'\n'+
+      red_gist+': '+GridGame.players[1].movelog+'\n'
+    );
     match.draw_match();
     match.add_to_csv();
     match.update_rankings();

--- a/run_tournament.js
+++ b/run_tournament.js
@@ -8,6 +8,10 @@ fs.writeFile(
   'data/rankings.csv',
   'Bot\t\Gist\tScore\tOutright\tTimeout\tDraws\tLosses\n'
 );
+fs.writeFile(
+  'data/movelog.txt',
+  ''
+);
 
 
 GridGame.init();


### PR DESCRIPTION
The key change here is using bind() to refresh the API, instead of recreating the API object; and recreating this binding every time the GridGame is reset.

I also made two not-strictly-necessary changes: moving the code that keeps track of APIs into the GridGame class (making it more obvious why refreshing the API itself wasn't working), and adding a movelog to the tournament output.